### PR TITLE
Source Id added to UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@
             contentdetailsDiv.innerHTML += `<br><strong>Mime Type:</strong> ` + content.contentMetadata.mime;
 
             // SourceId
-            if ("key" && "value" in content.contentMetadata.sourceId) {
+            if (content.contentMetadata.sourceId !== undefined) {
                 contentdetailsDiv.innerHTML += `<br><strong>Source ID:</strong> ` + content.contentMetadata.sourceId.key + ": " + content.contentMetadata.sourceId.value;
             }
 


### PR DESCRIPTION
Closes #12 

I added SourceId to the UI under the Following format

SOURCE ID: key: value

I'm unsure about the colon followed by another colon. 
We could simply keep the colon between key and value since Source ID stands out on its own as it uses a different font.

Another alternative could be to push the key and value to another line:

Source Id:
key: value


I placed it under mimetype but it might be better located elsewhere.
What do you think?
![image](https://user-images.githubusercontent.com/631268/215611980-f4920798-e01e-43cc-a9ca-2018c11b9108.png)


